### PR TITLE
Add project metric listing tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Simple WandB MCP Server
+
+A minimal FastMCP server exposing tools for interacting with
+[Weights & Biases](https://wandb.ai/).
+
+## Tools
+
+- `get_wandb_projects(entity: str)` – list projects for a W&B entity.
+- `list_wandb_runs(entity: str, project_name: str)` – list runs in a project.
+- `list_project_metrics(entity: str, project_name: str)` – show unique metric names
+  across all runs in a project.
+- `plot_run_metric(entity: str, project_name: str, run_id: str, metric_names: List[str])`
+  – generate a plot of selected metrics for a run.
+
+## Usage
+
+Ensure the environment variable `WANDB_API_KEY` is set and run:
+
+```bash
+python server.py
+```

--- a/server.py
+++ b/server.py
@@ -37,6 +37,23 @@ async def list_wandb_runs(entity: str, project_name: str) -> str:
         return f"Error fetching runs for '{project_name}': {e}"
 
 @mcp.tool()
+async def list_project_metrics(entity: str, project_name: str) -> str:
+    """List all unique metric names logged in a W&B project."""
+    if not project_name:
+        return "Project name is required."
+
+    try:
+        runs = api.runs(path=f"{entity}/{project_name}")
+        metrics = set()
+        for run in runs:
+            history = run.history(samples=1)
+            metrics.update([c for c in history.columns if not c.startswith("_")])
+
+        return "\n".join(sorted(metrics)) or f"No metrics found in '{project_name}'."
+    except Exception as e:
+        return f"Error fetching metrics for '{project_name}': {e}"
+
+@mcp.tool()
 async def plot_run_metric(entity: str, project_name: str, run_id: str, metric_names: List[str]) -> str:
     """
     Plot one or more metrics from a specific W&B run and return the image path.


### PR DESCRIPTION
## Summary
- add `list_project_metrics` tool to list metrics for a W&B project
- document all available tools in README

## Testing
- `python -m py_compile server.py`

------
https://chatgpt.com/codex/tasks/task_e_68518db859ac83328ef162766a0c3365